### PR TITLE
[autopatch] TEST BEFORE MERGE ynh_setup_source --full_replace=1

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -50,7 +50,7 @@ if [ "$upgrade_type" == "UPGRADE_APP" ]; then
     ynh_script_progression --message="Upgrading source files..." --weight=6
 
     # Download, check integrity, uncompress and patch the source from amd64.src
-    ynh_setup_source --dest_dir="$install_dir/package"
+    ynh_setup_source --dest_dir="$install_dir/package" --full_replace=1
 fi
 
 chmod -R o-rwx "$install_dir"


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** patch to potentially fix a bug in the upgrade script.

`ynh_setup_source` doesn't overwrite the destination directory, but rather extracts the source in the existing directory.

This might lead to weird cases where legacy source files aren't deleted.

The command has an argument `--full_replace=1` that fixes this behaviour.

BE CAREFUL because this change might lead to data losses! You should check that all the patches calls to `ynh_setup_source`
_do exactly what you expect to do_ and don't **delete user data**.

If you want exclude some files from being overwritten/deleted, use the `--keep` argument, just like that:

```bash
ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="config/config.yaml"
```